### PR TITLE
Update ci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.18.3
 
 commands:
   attach_workspace_at_project:


### PR DESCRIPTION
## Why?
CircleCI have deprecated their circleci docker images in favour of cimg
## What?
Now using cimg with a full node version number
## Anything in particular you'd like to highlight to reviewers?
No